### PR TITLE
Gemspec quality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,6 @@
 /spec/reports/
 /tmp/
 Gemfile.lock
+
+# ASDF-VM / rbenv
+.tool-versions

--- a/x.gemspec
+++ b/x.gemspec
@@ -25,9 +25,10 @@ Gem::Specification.new do |spec|
   spec.files = Dir[
     "bin/*",
     "lib/**/*.rb",
-    "sig/*.rbs"
+    "sig/*.rbs",
+    "*.md",
+    "LICENSE.txt"
   ]
-  spec.files += ["LICENSE.txt"] + Dir["*.md"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/x.gemspec
+++ b/x.gemspec
@@ -22,7 +22,11 @@ Gem::Specification.new do |spec|
     "documentation_uri" => "https://rubydoc.info/gems/x/"
   }
 
-  spec.files = Dir["bin/*"] + Dir["lib/**/*.rb"] + Dir["sig/*.rbs"]
+  spec.files = Dir[
+    "bin/*",
+    "lib/**/*.rb",
+    "sig/*.rbs"
+  ]
   spec.files += ["LICENSE.txt"] + Dir["*.md"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }

--- a/x.gemspec
+++ b/x.gemspec
@@ -19,16 +19,11 @@ Gem::Specification.new do |spec|
     "source_code_uri" => "https://github.com/sferik/x-ruby",
     "changelog_uri" => "https://github.com/sferik/x-ruby/blob/master/CHANGELOG.md",
     "bug_tracker_uri" => "https://github.com/sferik/x-ruby/issues",
-    "documentation_uri" => "https://rubydoc.info/gems/x/",
+    "documentation_uri" => "https://rubydoc.info/gems/x/"
   }
 
-  # Specify which files should be added to the gem when it is released.
-  # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files = Dir.chdir(__dir__) do
-    `git ls-files -z`.split("\x0").reject do |f|
-      (File.expand_path(f) == __FILE__) || f.start_with?(*%w[bin/ test/ spec/ features/ .git .circleci appveyor])
-    end
-  end
+  spec.files = Dir["bin/*"] + Dir["lib/**/*.rb"] + Dir["sig/*.rbs"]
+  spec.files += ["LICENSE.txt"] + Dir["*.md"]
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]

--- a/x.gemspec
+++ b/x.gemspec
@@ -10,12 +10,17 @@ Gem::Specification.new do |spec|
   spec.homepage = "https://sferik.github.io/x-ruby"
   spec.license = "MIT"
   spec.required_ruby_version = ">= 3.0"
+  spec.platform = Gem::Platform::RUBY
 
-  spec.metadata["allowed_push_host"] = "https://rubygems.org"
-
-  spec.metadata["homepage_uri"] = spec.homepage
-  spec.metadata["source_code_uri"] = "https://github.com/sferik/x-ruby"
-  spec.metadata["changelog_uri"] = "https://github.com/sferik/x-ruby/blob/master/CHANGELOG.md"
+  spec.metadata = {
+    "allowed_push_host" => "https://rubygems.org",
+    "rubygems_mfa_required" => "true",
+    "homepage_uri" => spec.homepage,
+    "source_code_uri" => "https://github.com/sferik/x-ruby",
+    "changelog_uri" => "https://github.com/sferik/x-ruby/blob/master/CHANGELOG.md",
+    "bug_tracker_uri" => "https://github.com/sferik/x-ruby/issues",
+    "documentation_uri" => "https://rubydoc.info/gems/x/",
+  }
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
@@ -27,8 +32,4 @@ Gem::Specification.new do |spec|
   spec.bindir = "exe"
   spec.executables = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
-
-  # For more information and examples about making a new gem, check out our
-  # guide at: https://bundler.io/guides/creating_gem.html
-  spec.metadata["rubygems_mfa_required"] = "true"
 end


### PR DESCRIPTION
- ignore virtual env files a147d8571313d0cdcde4237fd3a9394573d5e3d1
- better metadata and add platform 6b78109b76ee27efdc83f90979d4e6a460f92558
- better files 532d82101853a97479face53fd1e1c4eca30b2bc
  - remove dependency to git
  - not overcomplicated
  - allow list is better than deny list
  - remove files that don't need to be included in the gem (only needed for dev): .rubocop.yml, Rakefile, Steepfile, Gemfile