### PR TITLE
Allow Client to use a proxy url

### DIFF
--- a/lib/x/client.rb
+++ b/lib/x/client.rb
@@ -26,6 +26,7 @@ module X
       open_timeout: Connection::DEFAULT_OPEN_TIMEOUT,
       read_timeout: Connection::DEFAULT_READ_TIMEOUT,
       write_timeout: Connection::DEFAULT_WRITE_TIMEOUT,
+      proxy_url: nil,
       content_type: RequestBuilder::DEFAULT_CONTENT_TYPE,
       user_agent: RequestBuilder::DEFAULT_USER_AGENT,
       debug_output: nil,
@@ -35,7 +36,7 @@ module X
 
       initialize_authenticator(bearer_token, api_key, api_key_secret, access_token, access_token_secret)
       @connection = Connection.new(base_url: base_url, open_timeout: open_timeout, read_timeout: read_timeout,
-        write_timeout: write_timeout, debug_output: debug_output)
+        write_timeout: write_timeout, debug_output: debug_output, proxy_url: proxy_url)
       @request_builder = RequestBuilder.new(content_type: content_type, user_agent: user_agent)
       @redirect_handler = RedirectHandler.new(@authenticator, @connection, @request_builder,
         max_redirects: max_redirects)

--- a/lib/x/redirect_handler.rb
+++ b/lib/x/redirect_handler.rb
@@ -49,7 +49,7 @@ module X
     def send_new_request(new_uri, new_request)
       @connection = Connection.new(base_url: new_uri, open_timeout: connection.open_timeout,
         read_timeout: connection.read_timeout, write_timeout: connection.write_timeout,
-        debug_output: connection.debug_output)
+        debug_output: connection.debug_output, proxy_url: connection.proxy_uri)
       connection.send_request(new_request)
     end
   end

--- a/sig/x.rbs
+++ b/sig/x.rbs
@@ -93,10 +93,11 @@ module X
     @http_client: Net::HTTP
 
     attr_reader base_uri: URI::Generic
+    attr_reader proxy_uri: URI::Generic?
     attr_reader open_timeout : Float | Integer
     attr_reader read_timeout : Float | Integer
     attr_reader write_timeout : Float | Integer
-    def initialize: (?base_url: URI::Generic | String, ?open_timeout: Float | Integer, ?read_timeout: Float | Integer, ?write_timeout: Float | Integer, ?debug_output: IO?) -> void
+    def initialize: (?base_url: URI::Generic | String, ?open_timeout: Float | Integer, ?read_timeout: Float | Integer, ?write_timeout: Float | Integer, ?proxy_url: URI::Generic? | String?, ?debug_output: IO?) -> void
     def send_request: (Net::HTTPRequest request) -> Net::HTTPResponse
     def base_uri=: (URI::Generic | String base_url) -> void
     def debug_output: -> IO?
@@ -105,6 +106,7 @@ module X
     def apply_http_client_settings: (open_timeout: Float | Integer, read_timeout: Float | Integer, write_timeout: Float | Integer, debug_output: IO?) -> untyped
     def current_http_client_settings: -> {open_timeout: Float | Integer, read_timeout: Float | Integer, write_timeout: Float | Integer, debug_output: IO?}
     def update_http_client_settings: -> untyped
+    def build_http_client: (host: String, port: Integer) -> (Net::HTTP)
     def conditionally_apply_http_client_settings: { -> untyped } -> untyped
   end
 
@@ -168,7 +170,7 @@ module X
     @response_handler: ResponseHandler
 
     attr_reader base_uri: URI::Generic
-    def initialize: (?bearer_token: String?, ?api_key: String?, ?api_key_secret: String?, ?access_token: String?, ?access_token_secret: String?, ?base_url: URI::Generic | String, ?content_type: String, ?user_agent: String, ?open_timeout: Float | Integer, ?read_timeout: Float | Integer, ?write_timeout: Float | Integer, ?debug_output: IO?, ?array_class: Class, ?object_class: Class, ?max_redirects: Integer) -> void
+    def initialize: (?bearer_token: String?, ?api_key: String?, ?api_key_secret: String?, ?access_token: String?, ?access_token_secret: String?, ?base_url: URI::Generic | String, ?content_type: String, ?user_agent: String, ?open_timeout: Float | Integer, ?read_timeout: Float | Integer, ?write_timeout: Float | Integer, ?proxy_url: URI::Generic? | String?, ?debug_output: IO?, ?array_class: Class, ?object_class: Class, ?max_redirects: Integer) -> void
     def get: (String endpoint) -> Hash[String, untyped]
     def post: (String endpoint, ?nil body) -> Hash[String, untyped]
     def put: (String endpoint, ?nil body) -> Hash[String, untyped]

--- a/test/x/connection_test.rb
+++ b/test/x/connection_test.rb
@@ -22,4 +22,34 @@ class ConnectionTest < Minitest::Test
     assert_equal 10, @connection.http_client.read_timeout
     assert_equal 10, @connection.http_client.write_timeout
   end
+
+  def test_that_proxy_url_is_set_on_the_http_client
+    connection = X::Connection.new(proxy_url: "https://proxy.com:42")
+
+    assert_predicate connection.http_client, :proxy?
+    assert_equal "proxy.com", connection.http_client.proxy_address
+    assert_equal 42, connection.http_client.proxy_port
+  end
+
+  def test_that_authenticated_proxy_url_is_set_on_the_http_client
+    connection = X::Connection.new(proxy_url: "https://user:pass@proxy.com")
+
+    assert_predicate connection.http_client, :proxy?
+    assert_equal "user", connection.http_client.proxy_user
+    assert_equal "pass", connection.http_client.proxy_pass
+  end
+
+  def test_that_environment_variable_can_set_proxy_on_the_http_client
+    old_value = ENV.fetch("http_proxy", nil)
+
+    ENV["http_proxy"] = "https://proxy.com:42"
+
+    connection = X::Connection.new
+
+    assert_predicate connection.http_client, :proxy?
+    assert_equal "proxy.com", connection.http_client.proxy_address
+    assert_equal 42, connection.http_client.proxy_port
+  ensure
+    ENV["http_proxy"] = old_value
+  end
 end


### PR DESCRIPTION
This change adds a `proxy_url` option when creating the client.

If set, the `Net::HTTP` object will set the appropriate values and use a proxy server for the connection.