### PR TITLE
Ensure split chunks are written as binary

### DIFF
--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -71,7 +71,7 @@ module X
         File.open(file_path, "rb") do |f|
           while (chunk = f.read(chunk_size))
             file_paths << "#{Dir.mktmpdir}/x#{format("%03d", file_number += 1)}".tap do |path|
-              File.write(path, chunk)
+              File.binwrite(path, chunk)
             end
           end
         end


### PR DESCRIPTION
This may be enviroment-specific, but using `chunked_upload` was throwing the following exception:

```
Encoding::UndefinedConversionError: "\x89" from ASCII-8BIT to UTF-8
```

A simple fix will ensure the chunked files are written as binary.