### PR TITLE
Add information about all rate limits in TooManyRequests error

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -31,6 +31,11 @@ Layout/HashAlignment:
   EnforcedColonStyle: key
   EnforcedLastArgumentHashStyle: always_inspect
 
+Layout/MultilineMethodCallIndentation:
+  Enabled: true
+  EnforcedStyle: indented
+  IndentationWidth: ~
+
 Layout/ParameterAlignment:
   Enabled: true
   EnforcedStyle: with_fixed_indentation

--- a/README.md
+++ b/README.md
@@ -142,11 +142,16 @@ Pull requests will only be accepted if they meet all the following criteria:
 
 3. 100% mutation coverage. This can be verified with:
 
+       git remote add upstream https://github.com/sferik/x-ruby # The upstream branch has to be added
        bundle exec rake mutant
 
 4. RBS type signatures (in `sig/x.rbs`). This can be verified with:
 
        bundle exec rake steep
+
+5. Code must conform to [RuboCop rules](https://github.com/rubocop/rubocop). This can be verified with:
+
+       bundle exec rubocop
 
 ## License
 

--- a/lib/x/rate_limit.rb
+++ b/lib/x/rate_limit.rb
@@ -1,0 +1,28 @@
+module X
+  class RateLimit
+    attr_accessor :type, :response
+
+    def initialize(type:, response:)
+      @type = type
+      @response = response
+    end
+
+    def limit
+      Integer(response.fetch("x-#{type}-limit"))
+    end
+
+    def remaining
+      Integer(response.fetch("x-#{type}-remaining"))
+    end
+
+    def reset_at
+      Time.at(Integer(response.fetch("x-#{type}-reset")))
+    end
+
+    def reset_in
+      [(reset_at - Time.now).ceil, 0].max
+    end
+
+    alias_method :retry_after, :reset_in
+  end
+end

--- a/sig/x.rbs
+++ b/sig/x.rbs
@@ -102,12 +102,16 @@ module X
   end
 
   class TooManyRequests < ClientError
-    @response: Net::HTTPResponse
+    @rate_limits: Array[RateLimit]
+    @limit_types: Array[String]
 
-    def limit: -> Integer
-    def remaining: -> Integer
+    def rate_limit: -> RateLimit?
+    def rate_limits: -> Array[RateLimit]
     def reset_at: -> Time
     def reset_in: -> Integer?
+
+    private
+    def limit_types: -> Array[String]
   end
 
   class Unauthorized < ClientError
@@ -145,6 +149,16 @@ module X
     private
     def build_http_client: (?String host, ?Integer port) -> Net::HTTP
     def configure_http_client: (Net::HTTP http_client) -> Net::HTTP
+  end
+
+  class RateLimit
+    attr_accessor type: String
+    attr_accessor response: Net::HTTPResponse
+    def initialize: (type: String, response: Net::HTTPResponse) -> void
+    def limit: -> Integer
+    def remaining: -> Integer
+    def reset_at: -> Time
+    def reset_in: -> Integer?
   end
 
   class RequestBuilder

--- a/test/x/error_test.rb
+++ b/test/x/error_test.rb
@@ -30,61 +30,6 @@ module X
       end
     end
 
-    def test_rate_limit
-      headers = {"x-rate-limit-limit" => "40000", "x-rate-limit-remaining" => "39999"}
-      stub_request(:get, "https://api.twitter.com/2/tweets")
-        .to_return(status: 429, headers: headers)
-
-      begin
-        @client.get("tweets")
-      rescue TooManyRequests => e
-        assert_equal 40_000, e.limit
-        assert_equal 39_999, e.remaining
-      end
-    end
-
-    def test_rate_limit_reset_at
-      Time.stub :now, Time.utc(1983, 11, 24) do
-        reset_time = Time.now.to_i + 900
-        headers = {"x-rate-limit-reset" => reset_time.to_s}
-        stub_request(:get, "https://api.twitter.com/2/tweets").to_return(status: 429, headers: headers)
-
-        begin
-          @client.get("tweets")
-        rescue TooManyRequests => e
-          assert_equal Time.at(reset_time), e.reset_at
-        end
-      end
-    end
-
-    def test_rate_limit_reset_in
-      Time.stub :now, Time.utc(1983, 11, 24) do
-        reset_time = Time.now.to_i + 900
-        headers = {"x-rate-limit-reset" => reset_time.to_s}
-        stub_request(:get, "https://api.twitter.com/2/tweets").to_return(status: 429, headers: headers)
-
-        begin
-          @client.get("tweets")
-        rescue TooManyRequests => e
-          assert_equal 900, e.reset_in
-        end
-      end
-    end
-
-    def test_rate_limit_reset_is_not_negative
-      Time.stub :now, Time.utc(1983, 11, 24) do
-        reset_time = Time.now.to_i - 1
-        headers = {"content-type" => "application/json", "x-rate-limit-reset" => reset_time.to_s}
-        stub_request(:get, "https://api.twitter.com/2/tweets").to_return(status: 429, headers: headers, body: "{}")
-
-        begin
-          @client.get("tweets")
-        rescue TooManyRequests => e
-          assert_equal 0, e.reset_in
-        end
-      end
-    end
-
     def test_unexpected_response
       stub_request(:get, "https://api.twitter.com/2/tweets").to_return(status: 600)
 

--- a/test/x/rate_limit_test.rb
+++ b/test/x/rate_limit_test.rb
@@ -1,0 +1,50 @@
+require_relative "../test_helper"
+
+module X
+  class RateLimitTest < Minitest::Test
+    cover RateLimit
+
+    def setup
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        response = {
+          "x-rate-limit-limit" => "100",
+          "x-rate-limit-remaining" => "0",
+          "x-rate-limit-reset" => (Time.now.to_i + 60).to_s
+        }
+        @rate_limit = RateLimit.new(type: "rate-limit", response: response)
+      end
+    end
+
+    def test_limit
+      assert_equal 100, @rate_limit.limit
+    end
+
+    def test_remaining
+      assert_equal 0, @rate_limit.remaining
+    end
+
+    def test_reset_at
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        assert_equal Time.at(Time.now.to_i + 60), @rate_limit.reset_at
+      end
+    end
+
+    def test_reset_in
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        assert_equal 60, @rate_limit.reset_in
+      end
+    end
+
+    def test_reset_in_minimum_value
+      @rate_limit.response["x-rate-limit-reset"] = (Time.now.to_i - 60).to_s
+
+      assert_equal 0, @rate_limit.reset_in
+    end
+
+    def test_reset_in_ceil
+      @rate_limit.response["x-rate-limit-reset"] = (Time.now + 61).to_i.to_s
+
+      assert_equal 61, @rate_limit.reset_in
+    end
+  end
+end

--- a/test/x/response_parser_test.rb
+++ b/test/x/response_parser_test.rb
@@ -51,7 +51,7 @@ module X
         headers: {"x-rate-limit-remaining" => "0"})
       exception = assert_raises(TooManyRequests) { @response_parser.parse(response: response) }
 
-      assert_predicate exception.remaining, :zero?
+      assert_predicate exception.rate_limits.first.remaining, :zero?
     end
 
     def test_error_with_title_only

--- a/test/x/too_many_requests_test.rb
+++ b/test/x/too_many_requests_test.rb
@@ -10,6 +10,7 @@ module X
         response["x-rate-limit-limit"] = "100"
         response["x-rate-limit-remaining"] = "0"
         response["x-rate-limit-reset"] = (Time.now + 60).to_i.to_s
+
         @exception = TooManyRequests.new(response: response)
       end
     end
@@ -18,69 +19,75 @@ module X
       response = Net::HTTPTooManyRequests.new("1.1", 429, "Too Many Requests")
       exception = TooManyRequests.new(response: response)
 
-      assert_equal 0, exception.limit
-      assert_equal 0, exception.remaining
+      assert_equal 0, exception.rate_limits.count
       assert_equal Time.at(0).utc, exception.reset_at
       assert_equal 0, exception.reset_in
-      assert_equal "Too Many Requests", @exception.message
+      assert_equal "Too Many Requests", exception.message
     end
 
-    def test_limit
-      assert_equal 100, @exception.limit
+    def test_rate_limit
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        @exception.response["x-app-limit-24hour-reset"] = (Time.now + 61).to_i.to_s
+        @exception.response["x-app-limit-24hour-remaining"] = "0"
+
+        assert_equal Time.now + 61, @exception.rate_limit.reset_at
+      end
     end
 
-    def test_limit_with_header
-      response = Net::HTTPTooManyRequests.new("1.1", 429, "Too Many Requests")
-      response["x-rate-limit-limit"] = "100"
-      exception = TooManyRequests.new(response: response)
+    def test_rate_limits
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        @exception.response["x-app-limit-24hour-limit"] = "200"
+        @exception.response["x-app-limit-24hour-remaining"] = "0"
+        limits = @exception.rate_limits
 
-      assert_equal 100, exception.limit
+        assert_equal 2, limits.count
+        assert_equal "rate-limit", limits.first.type
+        assert_equal "app-limit-24hour", limits.last.type
+      end
     end
 
-    def test_remaining
-      assert_equal 0, @exception.remaining
-    end
+    def test_rate_limits_exlude_non_exhausted_limits
+      Time.stub :now, Time.utc(1983, 11, 24) do
+        @exception.response["x-app-limit-24hour-limit"] = "200"
+        @exception.response["x-app-limit-24hour-remaining"] = "1"
+        limits = @exception.rate_limits
 
-    def test_remaining_with_header
-      response = Net::HTTPTooManyRequests.new("1.1", 429, "Too Many Requests")
-      response["x-rate-limit-remaining"] = "5"
-      exception = TooManyRequests.new(response: response)
-
-      assert_equal 5, exception.remaining
+        assert_equal 1, limits.count
+        assert_equal "rate-limit", limits.first.type
+      end
     end
 
     def test_reset_at
       Time.stub :now, Time.utc(1983, 11, 24) do
-        assert_equal Time.now + 60, @exception.reset_at
+        @exception.response["x-app-limit-24hour-remaining"] = "0"
+        @exception.response["x-app-limit-24hour-reset"] = (Time.now + 200).to_i.to_s
+
+        assert_equal Time.at(Time.now.to_i + 200), @exception.reset_at
       end
     end
 
     def test_reset_in
       Time.stub :now, Time.utc(1983, 11, 24) do
-        assert_equal 60, @exception.reset_in
+        @exception.response["x-app-limit-24hour-remaining"] = "0"
+        @exception.response["x-app-limit-24hour-reset"] = (Time.now + 200).to_i.to_s
+
+        assert_equal 200, @exception.reset_in
       end
+    end
+
+    def test_reset_in_ceil
+      @exception.response["x-rate-limit-reset"] = (Time.now + 61).to_i.to_s
+
+      assert_equal 61, @exception.reset_in
     end
 
     def test_retry_after
       Time.stub :now, Time.utc(1983, 11, 24) do
-        assert_equal 60, @exception.retry_after
+        @exception.response["x-app-limit-24hour-remaining"] = "0"
+        @exception.response["x-app-limit-24hour-reset"] = (Time.now + 200).to_i.to_s
+
+        assert_equal 200, @exception.retry_after
       end
-    end
-
-    def test_reset_in_minimum_value
-      response = Net::HTTPTooManyRequests.new("1.1", 429, "Too Many Requests")
-      response["x-rate-limit-reset"] = (Time.now - 60).to_i.to_s
-      exception = TooManyRequests.new(response: response)
-
-      assert_equal 0, exception.reset_in
-    end
-
-    def test_reset_in_ceil
-      response = Net::HTTPTooManyRequests.new("1.1", 429, "Too Many Requests")
-      response["x-rate-limit-reset"] = (Time.now + 61).to_i.to_s
-      exception = TooManyRequests.new(response: response)
-
-      assert_equal 61, exception.reset_in
     end
   end
 end


### PR DESCRIPTION
Some endpoints have different kind of limits as [DMs](https://developer.twitter.com/en/docs/twitter-api/direct-messages/manage/api-reference/post-dm_conversations-with-participant_id-messages) and [Likes](https://developer.twitter.com/en/docs/twitter-api/tweets/likes/api-reference/post-users-id-likes).

I found no official list of headers, but I saw x-user-limit-24hour-limit and x-app-limit-24hour-limit.

For example, when the 15 minutes and 24 hours limits of requests allowed "POST likes" are reached, `x-rate-limit-reset` gives the next reset for the 15 minutes limit. The reset time for the 24 hours limit is displayed in `x-user-limit-24hour-reset`. Every request performed before the time in `x-user-limit-24hour-reset` will fail.

I added the code to have the information about all limits and changed `retry_after` to return the time that we can send requests again.

This script :
```
begin
  body = {
    "tweet_id": "<id>"
  }
  client.post("users/<user id>/likes", JSON.dump(body))
rescue X::TooManyRequests => e
  pp e.overall_limits
  pp e.next_available_at
end
```

Return this value :

```
{"rate-limit"=>{"limit"=>50, "remaining"=>22, "reset_at"=>2023-11-28 17:05:49 -0500}, "user-limit-24hour"=>{"limit"=>1000, "remaining"=>0, "reset_at"=>2023-11-29 13:59:38 -0500}}
2023-11-29 13:59:38 -0500
```
