### PR TITLE
Add base64 to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source "https://rubygems.org"
 # Specify your gem's dependencies in x.gemspec
 gemspec
 
+gem "base64", ">= 0.2"
 gem "minitest", ">= 5.19"
 gem "mutant", ">= 0.12"
 gem "mutant-minitest", ">= 0.11.24"


### PR DESCRIPTION
This PR adds `base64` to the Gemfile.

**base64** will not be part of the default gems since Ruby 3.4.0. This change silences the following warning:

```
/gems/x-0.14.1/lib/x/oauth_authenticator.rb:1: warning: base64 was loaded from the standard library, 
but will no longer be part of the default gems since Ruby 3.4.0. Add base64 to your Gemfile or gemspec
```