### PR TITLE
Fix commas in GET URIs being transformed into %2C

### DIFF
--- a/lib/x/request_builder.rb
+++ b/lib/x/request_builder.rb
@@ -50,7 +50,9 @@ module X
     end
 
     def escape_query_params(uri)
-      URI(uri).tap { |u| u.query = URI.encode_www_form(URI.decode_www_form(u.query)) if u.query }
+      URI(uri).tap do |u|
+        u.query = URI.encode_www_form(URI.decode_www_form(u.query)).gsub("%2C", ",") if u.query
+      end
     end
   end
 end

--- a/test/x/request_builder_test.rb
+++ b/test/x/request_builder_test.rb
@@ -68,5 +68,12 @@ module X
 
       assert_equal "media_type=video%2Fmp4", request.uri.query
     end
+
+    def test_escape_query_params_with_commas
+      uri = "https://api.twitter.com/2/tweets/search/recent?query=%23ruby&expansions=author_id&user.fields=id,name,username"
+      request = @request_builder.build(http_method: :post, uri:, authenticator: @authenticator)
+
+      assert_equal "query=%23ruby&expansions=author_id&user.fields=id,name,username", request.uri.query
+    end
   end
 end


### PR DESCRIPTION
Commas in the query params are being transformed into `%2C` on the URL sent to X. This change fixes those params to correct send as commas as X expects.