### PR TITLE
Use media_id to upload media

### DIFF
--- a/examples/chunked_media_upload.rb
+++ b/examples/chunked_media_upload.rb
@@ -16,7 +16,7 @@ media = X::MediaUploader.chunked_upload(client:, file_path:, media_category:)
 
 X::MediaUploader.await_processing(client:, media:)
 
-tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["media_id_string"]]}}
+tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["id"]]}}
 
 tweet = client.post("tweets", tweet_body.to_json)
 

--- a/examples/post_media_upload.rb
+++ b/examples/post_media_upload.rb
@@ -14,7 +14,7 @@ media_category = "tweet_image" # other options are: dm_image or subtitles; for v
 
 media = X::MediaUploader.upload(client:, file_path:, media_category:)
 
-tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["media_id_string"]]}}
+tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["id"]]}}
 
 tweet = client.post("tweets", tweet_body.to_json)
 

--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -30,12 +30,12 @@ module X
       media = init(client:, file_path:, media_type:, media_category:)
       chunk_size = chunk_size_mb * BYTES_PER_MB
       append(client:, file_paths: split(file_path, chunk_size), media:, media_type:, boundary:)
-      client.post("media/upload?command=FINALIZE&media_key=#{media["media_key"]}")&.fetch("data")
+      client.post("media/upload?command=FINALIZE&media_id=#{media["id"]}")&.fetch("data")
     end
 
     def await_processing(client:, media:)
       loop do
-        status = client.get("media/upload?command=STATUS&media_key=#{media["media_key"]}")&.fetch("data")
+        status = client.get("media/upload?command=STATUS&media_id=#{media["id"]}")&.fetch("data")
         return status if !status["processing_info"] || PROCESSING_INFO_STATES.include?(status["processing_info"]["state"])
 
         sleep status["processing_info"]["check_after_secs"].to_i
@@ -85,7 +85,7 @@ module X
       threads = file_paths.map.with_index do |file_path, index|
         Thread.new do
           upload_body = construct_upload_body(file_path:, media_type:, boundary:)
-          query = "command=APPEND&media_key=#{media["media_key"]}&segment_index=#{index}"
+          query = "command=APPEND&media_id=#{media["id"]}&segment_index=#{index}"
           headers = {"Content-Type" => "multipart/form-data, boundary=#{boundary}"}
           upload_chunk(client:, query:, upload_body:, file_path:, headers:)
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -22,7 +22,6 @@ TEST_ACCESS_TOKEN_SECRET = "TEST_ACCESS_TOKEN_SECRET".freeze
 TEST_OAUTH_NONCE = "TEST_OAUTH_NONCE".freeze
 TEST_OAUTH_TIMESTAMP = Time.utc(1983, 11, 24).to_i.to_s
 TEST_MEDIA_ID = "TEST_MEDIA_ID".freeze
-TEST_MEDIA_KEY = "TEST_MEDIA_KEY".freeze
 
 def test_oauth_credentials
   {


### PR DESCRIPTION
X recently changed, so we have to use "media_id" instead of "media_key" in requests to upload media.

It fixes https://github.com/sferik/x-ruby/issues/42