### PR TITLE
Set binary read for media files to be uploaded

### DIFF
--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -112,7 +112,7 @@ module X
       "--#{boundary}\r\n" \
         "Content-Disposition: form-data; name=\"media\"; filename=\"#{File.basename(file_path)}\"\r\n" \
         "Content-Type: #{media_type}\r\n\r\n" \
-        "#{File.read(file_path)}\r\n" \
+        "#{File.binread(file_path)}\r\n" \
         "--#{boundary}--\r\n"
     end
   end


### PR DESCRIPTION
Addresses issue #47 

It prevents this error:

```
Encoding::CompatibilityError: invalid byte sequence in UTF-8 (Encoding::CompatibilityError)
```