### PR TITLE
Use dedicated endpoints for chunked media upload

### DIFF
--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -110,11 +110,11 @@ module X
     def construct_upload_body(file_path:, media_type:, segment_index: nil, boundary: SecureRandom.hex)
       body = ""
       if segment_index
-        body = "--#{boundary}\r\n" \
+        body += "--#{boundary}\r\n" \
           "Content-Disposition: form-data; name=\"segment_index\"\r\n\r\n" \
           "#{segment_index}\r\n"
       end
-      body += "--#{boundary}\r\n" \
+      "#{body}--#{boundary}\r\n" \
         "Content-Disposition: form-data; name=\"media\"; filename=\"#{File.basename(file_path)}\"\r\n" \
         "Content-Type: #{media_type}\r\n\r\n" \
         "#{File.binread(file_path)}\r\n" \

--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -109,11 +109,7 @@ module X
 
     def construct_upload_body(file_path:, media_type:, segment_index: nil, boundary: SecureRandom.hex)
       body = ""
-      if segment_index
-        body += "--#{boundary}\r\n" \
-          "Content-Disposition: form-data; name=\"segment_index\"\r\n\r\n" \
-          "#{segment_index}\r\n"
-      end
+      body += "--#{boundary}\r\nContent-Disposition: form-data; name=\"segment_index\"\r\n\r\n#{segment_index}\r\n" if segment_index
       "#{body}--#{boundary}\r\n" \
         "Content-Disposition: form-data; name=\"media\"; filename=\"#{File.basename(file_path)}\"\r\n" \
         "Content-Type: #{media_type}\r\n\r\n" \

--- a/sig/x.rbs
+++ b/sig/x.rbs
@@ -275,9 +275,9 @@ module X
     def split: (String file_path, Integer chunk_size) -> Array[String]
     def init: (client: Client, file_path: String, media_type: String, media_category: String) -> untyped
     def append: (client: Client, file_paths: Array[String], media: untyped, media_type: String, ?boundary: String) -> Array[String]
-    def upload_chunk: (client: Client, query: String, upload_body: String, file_path: String, ?headers: Hash[String, String]) -> Integer?
+    def upload_chunk: (client: Client, media_id: String, upload_body: String, file_path: String, ?headers: Hash[String, String]) -> Integer?
     def cleanup_file: (String file_path) -> Integer?
     def finalize: (client: Client, media: untyped) -> untyped
-    def construct_upload_body: (file_path: String, media_type: String, ?boundary: String) -> String
+    def construct_upload_body: (file_path: String, media_type: String, ?segment_index: Integer, ?boundary: String) -> String
   end
 end

--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -55,7 +55,7 @@ module X
       end
 
       file_paths.each_with_index do |_, segment_index|
-        assert_includes(bodies.reverse[segment_index], "Content-Disposition: form-data; name=\"segment_index\"\r\n\r\n#{segment_index}\r\n")
+        assert(bodies.one? { |body| body.include?("Content-Disposition: form-data; name=\"segment_index\"\r\n\r\n#{segment_index}\r\n") })
       end
     end
 

--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -27,12 +27,12 @@ module X
       chunk_size_mb = (total_bytes - 1) / MediaUploader::BYTES_PER_MB.to_f
       stub_request(:post, "https://api.twitter.com/2/media/upload/initialize").with(
         body: {
-          media_type: 'video/mp4',
-          media_category: 'tweet_video',
+          media_type: "video/mp4",
+          media_category: "tweet_video",
           total_bytes: total_bytes
         }.to_json
       ).to_return(status: 202, headers: {"content-type" => "application/json"}, body: @data.to_json)
-      2.times { |segment_index| stub_request(:post, "https://api.twitter.com/2/media/upload/#{TEST_MEDIA_ID}/append").to_return(status: 204) }
+      stub_request(:post, "https://api.twitter.com/2/media/upload/#{TEST_MEDIA_ID}/append").to_return(status: 204)
       stub_request(:post, "https://api.twitter.com/2/media/upload/#{TEST_MEDIA_ID}/finalize")
         .to_return(status: 201, headers: {"content-type" => "application/json"}, body: @data.to_json)
 
@@ -45,10 +45,8 @@ module X
       file_path = "test/sample_files/sample.mp4"
       file_paths = MediaUploader.send(:split, file_path, File.size(file_path) - 1)
 
-      file_paths.each_with_index do |_chunk_path, segment_index|
-        stub_request(:post, "https://api.twitter.com/2/media/upload/#{TEST_MEDIA_ID}/append")
-          .with(headers: {"Content-Type" => "multipart/form-data, boundary=AaB03x"}).to_return(status: 204)
-      end
+      stub_request(:post, "https://api.twitter.com/2/media/upload/#{TEST_MEDIA_ID}/append")
+        .with(headers: {"Content-Type" => "multipart/form-data, boundary=AaB03x"}).to_return(status: 204)
       MediaUploader.send(:append, client: @client, file_paths:, media: @media, media_type: "video/mp4", boundary: "AaB03x")
 
       bodies = []
@@ -83,8 +81,8 @@ module X
       file_path = "test/sample_files/sample.mp4"
       stub_request(:post, "https://api.twitter.com/2/media/upload/initialize").with(
         body: {
-          media_type: 'video/mp4',
-          media_category: 'tweet_video',
+          media_type: "video/mp4",
+          media_category: "tweet_video",
           total_bytes: File.size(file_path)
         }.to_json
       ).to_return(status: 202, headers: {"content-type" => "application/json"}, body: @data.to_json)


### PR DESCRIPTION
This fix #51 

I implemented changes described [here](https://devcommunity.x.com/t/media-upload-endpoints-update-and-extended-migration-deadline/241818)