### PR TITLE
Await processing on upload

### DIFF
--- a/examples/chunked_media_upload.rb
+++ b/examples/chunked_media_upload.rb
@@ -14,7 +14,7 @@ media_category = "tweet_video" # other options include: tweet_image, tweet_gif, 
 
 media = X::MediaUploader.chunked_upload(client:, file_path:, media_category:)
 
-X::MediaUploader.await_processing(client:, media:)
+X::MediaUploader.await_processing(client:, media:) # or X::MediaUploader.await_processing!(client:, media:) to raise an error if processing fails
 
 tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["id"]]}}
 

--- a/examples/chunked_media_upload.rb
+++ b/examples/chunked_media_upload.rb
@@ -14,7 +14,7 @@ media_category = "tweet_video" # other options include: tweet_image, tweet_gif, 
 
 media = X::MediaUploader.chunked_upload(client:, file_path:, media_category:)
 
-X::MediaUploader.await_processing(client:, media:) # or X::MediaUploader.await_processing!(client:, media:) to raise an error if processing fails
+X::MediaUploader.await_processing(client:, media:) # or X::MediaUploader.await_processing!(client:, media:) to raise an error if fails
 
 tweet_body = {text: "Posting media from @gem!", media: {media_ids: [media["id"]]}}
 

--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -42,6 +42,12 @@ module X
       end
     end
 
+    def await_processing!(client:, media:)
+      await_processing(client:, media:).tap do |status|
+        raise "Media processing failed" if status["processing_info"]["state"] == "failed"
+      end
+    end
+
     private
 
     def validate!(file_path:, media_category:)

--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -72,8 +72,9 @@ module X
       stub_request(:get, "https://api.twitter.com/2/media/upload?command=STATUS&media_id=#{TEST_MEDIA_ID}")
         .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "pending"}}}')
         .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "succeeded"}}}')
-            
-      result = MediaUploader.await_processing!(client: @client, media: @media)
+
+      result = MediaUploader.await_processing!(client: @client, media: MEDIA)
+
       assert_equal "succeeded", result["processing_info"]["state"]
     end
 
@@ -82,7 +83,7 @@ module X
         .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "pending"}}}')
         .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "failed"}}}')
       assert_raises(RuntimeError, "Media processing failed") do
-        MediaUploader.await_processing!(client: @client, media: @media)
+        MediaUploader.await_processing!(client: @client, media: MEDIA)
       end
       assert_requested(:get, "https://api.twitter.com/2/media/upload?command=STATUS&media_id=#{TEST_MEDIA_ID}", times: 2)
     end

--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -68,6 +68,25 @@ module X
       assert_equal "failed", response["processing_info"]["state"]
     end
 
+    def test_await_processing!
+      stub_request(:get, "https://api.twitter.com/2/media/upload?command=STATUS&media_id=#{TEST_MEDIA_ID}")
+        .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "pending"}}}')
+        .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "succeeded"}}}')
+            
+      result = MediaUploader.await_processing!(client: @client, media: @media)
+      assert_equal "succeeded", result["processing_info"]["state"]
+    end
+
+    def test_await_processing_and_failed!
+      stub_request(:get, "https://api.twitter.com/2/media/upload?command=STATUS&media_id=#{TEST_MEDIA_ID}")
+        .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "pending"}}}')
+        .to_return(headers: {"content-type" => "application/json"}, body: '{"data":{"processing_info": {"state": "failed"}}}')
+      assert_raises(RuntimeError, "Media processing failed") do
+        MediaUploader.await_processing!(client: @client, media: @media)
+      end
+      assert_requested(:get, "https://api.twitter.com/2/media/upload?command=STATUS&media_id=#{TEST_MEDIA_ID}", times: 2)
+    end
+
     def test_retry
       file_path = "test/sample_files/sample.mp4"
       body_json = {media_type: "video/mp4", media_category: "tweet_video", total_bytes: File.size(file_path)}.to_json


### PR DESCRIPTION
As discussed in issue #52, added the function stub from @GCorbel 's comment.
Added two tests: one to assert success is still returned, and another to assert the error was raised.
Also added a comment mentioning this feature in the chunked_upload example.

Rubocop warnings: both `media_uploader.rb` (101/100) and `media_uploader_test.rb` (107/100) ended up with more lines than allowed. What should I do here?
