### PR TITLE
Move media_category in body for media upload

### DIFF
--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -42,12 +42,6 @@ module X
       end
     end
 
-    def await_processing!(client:, media:)
-      await_processing(client:, media:).tap do |status|
-        raise Error.new("Media processing failed") if status["processing_info"]["state"] == "failed"
-      end
-    end
-
     private
 
     def validate!(file_path:, media_category:)

--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -16,8 +16,12 @@ module X
 
     def test_upload
       file_path = "test/sample_files/sample.jpg"
-      stub_request(:post, "#{BASE_URL}?media_category=#{MediaUploader::TWEET_IMAGE}").to_return(body: MEDIA.to_json, headers: JSON_HEADERS)
+      stub_request(:post, BASE_URL).to_return(body: MEDIA.to_json, headers: JSON_HEADERS)
       response = MediaUploader.upload(client: @client, file_path:, media_category: MediaUploader::TWEET_IMAGE, boundary: BOUNDARY)
+
+      assert_requested(:post, "https://api.twitter.com/2/media/upload", times: 1) do |request|
+        assert(request.body.include?("Content-Disposition: form-data; name=\"media_category\"\r\n\r\n#{MediaUploader::TWEET_IMAGE}"))
+      end
 
       assert_equal TEST_MEDIA_ID, response["id"]
     end


### PR DESCRIPTION
This PR fix https://github.com/sferik/x-ruby/issues/59.


Previously, we were able to send media_category as a URL parameter for the [/2/media/upload](https://docs.x.com/x-api/media/image-or-subtitle-media-upload) endpoint, but now it has to be in the body.