### PR TITLE
Fix nil status handling in MediaUploader processing

### DIFF
--- a/lib/x/media_uploader.rb
+++ b/lib/x/media_uploader.rb
@@ -33,21 +33,21 @@ module X
       client.post("media/upload/#{media["id"]}/finalize")&.fetch("data")
     end
 
-    def await_processing(client:, media:)
-      loop do
-        status = client.get("media/upload?command=STATUS&media_id=#{media["id"]}")&.fetch("data")
-        return status if !status["processing_info"] || PROCESSING_INFO_STATES.include?(status["processing_info"]["state"])
+      def await_processing(client:, media:)
+        loop do
+          status = client.get("media/upload?command=STATUS&media_id=#{media["id"]}")&.fetch("data")
+          return status if status.nil? || !status["processing_info"] || PROCESSING_INFO_STATES.include?(status["processing_info"]["state"])
 
-        sleep status["processing_info"]["check_after_secs"].to_i
+          sleep status["processing_info"]["check_after_secs"].to_i
+        end
       end
-    end
 
-    def await_processing!(client:, media:)
-      status = await_processing(client:, media:)
-      raise "Media processing failed" if status["processing_info"]["state"] == "failed"
+      def await_processing!(client:, media:)
+        status = await_processing(client:, media:)
+        raise "Media processing failed" if status&.dig("processing_info", "state") == "failed"
 
-      status
-    end
+        status
+      end
 
     private
 


### PR DESCRIPTION
## Summary
- ensure `MediaUploader.await_processing` can handle nil responses
- guard `MediaUploader.await_processing!` against missing `processing_info`

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6840febf6f2c832783430d5d5f4ee161