### PR TITLE
docs: fix credentials typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Or, if Bundler is not being used to manage dependencies:
 
 ## Usage
 
-First, obtain X credentails from <https://developer.x.com>.
+First, obtain X credentials from <https://developer.x.com>.
 
 ```ruby
 require "x"


### PR DESCRIPTION
## Summary
- fix a misspelling in the README usage section

## Testing
- `n/a`

------
https://chatgpt.com/codex/tasks/task_e_6841033a9360832785895c7c8d92ad06