### PR TITLE
Fix follower ID accumulation

### DIFF
--- a/examples/pagination.rb
+++ b/examples/pagination.rb
@@ -16,7 +16,7 @@ follower_ids = []
 
 loop do
   response = client.get("followers/ids.json?screen_name=#{screen_name}&count=#{count}&cursor=#{cursor}")
-  follower_ids << response["ids"]
+  follower_ids.concat(response["ids"])
   cursor = response["next_cursor"]
   break if cursor.zero?
 rescue X::TooManyRequests => e


### PR DESCRIPTION
## Summary
- fix pagination example to append follower IDs correctly

## Testing
- `bundle exec rake test` *(fails: Could not find gem 'fiddle (>= 1.1.2)' in locally installed gems)*

------
https://chatgpt.com/codex/tasks/task_e_6841036299d883279a037434ddad6fcc