### PR TITLE
Add assert_requested checks for MediaUploader retry

### DIFF
--- a/test/x/media_uploader_test.rb
+++ b/test/x/media_uploader_test.rb
@@ -88,6 +88,8 @@ module X
       stub_request(:post, "#{BASE_URL}/#{TEST_MEDIA_ID}/finalize").to_return(status: 201, headers: JSON_HEADERS, body: JSON_BODY)
 
       assert MediaUploader.chunked_upload(client: @client, file_path:, media_category: MediaUploader::TWEET_VIDEO)
+      assert_requested(:post, "#{BASE_URL}/#{TEST_MEDIA_ID}/append", times: 2)
+      assert_requested(:post, "#{BASE_URL}/#{TEST_MEDIA_ID}/finalize", times: 1)
     end
 
     def test_validate


### PR DESCRIPTION
## Summary
- ensure the retry logic in `MediaUploader.chunked_upload` is verified
- assert append endpoint is called twice and finalize once in retry test

## Testing
- `bundle exec rake test`

------
https://chatgpt.com/codex/tasks/task_e_6841037fd6008327a07fb43064114aba