### PR TITLE
Add example for updating profile images

### DIFF
--- a/examples/upload_profile_media.rb
+++ b/examples/upload_profile_media.rb
@@ -1,0 +1,22 @@
+require "base64"
+require "uri"
+require "x"
+
+x_credentials = {
+  api_key: "INSERT YOUR X API KEY HERE",
+  api_key_secret: "INSERT YOUR X API KEY SECRET HERE",
+  access_token: "INSERT YOUR X ACCESS TOKEN HERE",
+  access_token_secret: "INSERT YOUR X ACCESS TOKEN SECRET HERE"
+}
+
+client = X::Client.new(base_url: "https://api.twitter.com/1.1/", **x_credentials)
+
+avatar_path = "path/to/avatar.jpg"
+avatar_data = Base64.encode64(File.binread(avatar_path))
+avatar_body = URI.encode_www_form(image: avatar_data)
+client.post("account/update_profile_image.json", avatar_body, headers: {"Content-Type" => "application/x-www-form-urlencoded"})
+
+banner_path = "path/to/banner.jpg"
+banner_data = Base64.encode64(File.binread(banner_path))
+banner_body = URI.encode_www_form(banner: banner_data)
+client.post("account/update_profile_banner.json", banner_body, headers: {"Content-Type" => "application/x-www-form-urlencoded"})


### PR DESCRIPTION
## Summary
- add `upload_profile_media.rb` example for updating profile image and banner via v1.1 endpoints

## Testing
- `bin/setup`
- `bundle exec rake`


------
https://chatgpt.com/codex/tasks/task_e_68411ac378d48327a75af15426de33d1